### PR TITLE
Feature/drag and drop composable

### DIFF
--- a/src/components/ColumnTask.vue
+++ b/src/components/ColumnTask.vue
@@ -1,6 +1,7 @@
 <template>
   <drop-wrapper
     v-slot="{ isOver }"
+    :can-drop="draggedItem?.type === 'task'"
     class="mb-2"
     @drop="handleDrop($event, columnIndex, taskIndex)"
   >
@@ -51,6 +52,7 @@ import DragWrapper from "@/components/drag-and-drop/DragWrapper.vue";
 import DropWrapper from "@/components/drag-and-drop/DropWrapper.vue";
 import { useBoardStore } from "@/stores";
 import type { Column, Task } from "@/models";
+import { useDragAndDrop } from "@/composables/dragAndDrop";
 
 defineProps<{
   task: Task;
@@ -61,6 +63,7 @@ defineProps<{
 
 const board = useBoardStore();
 const { handleDrop } = useBoard();
+const { draggedItem } = useDragAndDrop();
 
 const showDeleteZone = ref(false);
 </script>

--- a/src/components/drag-and-drop/DragWrapper.vue
+++ b/src/components/drag-and-drop/DragWrapper.vue
@@ -13,10 +13,14 @@
 
 <script lang="ts" setup>
 import { ref } from "vue";
+import { useDragAndDrop } from "@/composables/dragAndDrop";
+import type { TransferData } from "@/composables/board";
 
 const props = defineProps<{
-  transferData: unknown;
+  transferData: TransferData;
 }>();
+
+const { draggedItem } = useDragAndDrop();
 
 const isDragging = ref(false);
 
@@ -25,6 +29,7 @@ const drag = (event: DragEvent): void => {
     event.dataTransfer.effectAllowed = "copy";
     event.dataTransfer.dropEffect = "copy";
     event.dataTransfer.setData("payload", JSON.stringify(props.transferData));
+    draggedItem.value = props.transferData;
     isDragging.value = true;
   }
 };

--- a/src/components/drag-and-drop/DropWrapper.vue
+++ b/src/components/drag-and-drop/DropWrapper.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    :class="{ 'bg-green-100 bg-stripes bg-07': isOver }"
+    :class="{ 'bg-green-100 bg-stripes bg-07': isOver && canDrop }"
     @dragenter.prevent
     @dragleave.prevent="isOver = false"
-    @dragover.prevent="isOver = true"
+    @dragover.prevent="canDrop && (isOver = true)"
     @drop.stop="drop"
   >
     <slot :is-over="isOver" />
@@ -13,6 +13,11 @@
 <script lang="ts" setup>
 import { ref } from "vue";
 
+const props = withDefaults(
+  defineProps<{ canDrop?: boolean; }>(),
+  { canDrop: true }
+);
+
 const emit = defineEmits<{
   (eventName: "drop", payload: unknown): void,
 }>();
@@ -20,7 +25,7 @@ const emit = defineEmits<{
 const isOver = ref(false);
 
 const drop = (event: DragEvent): void => {
-  if (event.dataTransfer) {
+  if (props.canDrop && event.dataTransfer) {
     const payload = event.dataTransfer.getData("payload");
     if (payload) {
       const transferData = JSON.parse(payload);

--- a/src/composables/board.ts
+++ b/src/composables/board.ts
@@ -1,5 +1,7 @@
 import type { Task } from "@/models";
 import { useBoardStore } from "@/stores";
+import { useDragAndDrop } from "@/composables/dragAndDrop";
+const { draggedItem } = useDragAndDrop();
 
 export interface TransferData {
   type: string;
@@ -70,6 +72,7 @@ export const useBoard = (board = useBoardStore()): UseBoard => {
     } else {
       moveColumn(transferData, toColumnIndex);
     }
+    draggedItem.value = null;
   };
 
   return {

--- a/src/composables/dragAndDrop.ts
+++ b/src/composables/dragAndDrop.ts
@@ -1,11 +1,8 @@
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { TransferData } from "@/composables/board";
 
 const draggedItem = ref<TransferData | null>(null);
-watch(draggedItem, (newVal, oldValue) => {
-  console.log("%c Line: old, msg: : ", "color: yellow", oldValue);
-  console.log("%c Line: new, msg: : ", "color: lightseagreen", newVal);
-});
+
 export const useDragAndDrop = () => {
   return {
     draggedItem,

--- a/src/composables/dragAndDrop.ts
+++ b/src/composables/dragAndDrop.ts
@@ -1,0 +1,13 @@
+import { ref, watch } from "vue";
+import { TransferData } from "@/composables/board";
+
+const draggedItem = ref<TransferData | null>(null);
+watch(draggedItem, (newVal, oldValue) => {
+  console.log("%c Line: old, msg: : ", "color: yellow", oldValue);
+  console.log("%c Line: new, msg: : ", "color: lightseagreen", newVal);
+});
+export const useDragAndDrop = () => {
+  return {
+    draggedItem,
+  };
+};

--- a/src/views/TheBoard.vue
+++ b/src/views/TheBoard.vue
@@ -41,7 +41,7 @@ const newColumnName = ref("");
 
 <style>
 .board {
-  @apply p-4 bg-teal-100 h-screen overflow-auto relative;
+  @apply p-4 bg-teal-100 h-screen overflow-auto;
 }
 
 .task-bg {


### PR DESCRIPTION
### Added simple composable to store the dragged item. 

**Reasoning**: Be able to determine what type of item is being dragged over. With this information I can determine if item can be dropped.

**Example**: "_Column_" is being dragged over "_Task_". We want to forbidden dropping the _Column_ on the _Task_. Column needs to be dropped on a Column.

**Implementation note**:
- Custom transfer added to `event.dataTransfer` on `dragstart` is not accessible  on `dragover | dragenter | dragend | dragleave | drag`. It is accessible only on `dragstart | drop` events.
- For this reason I decided to store `item` in the Composable `ref`.

**Final note**: I am aware the solution is not perfect. We could use only created Composable and ditch using `event.dataTransfer` at all.  However the purpose of working on this project was to learn more about "_drag and drop_" Browser feature. This repo remains a reference to this learning process and that is why I am going to keep it this "mixed" implementation of both.